### PR TITLE
Updates sequelize to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "morgan": "^1.9.1",
     "nodemailer": "^4.6.8",
     "pg": "^6.0.0",
-    "sequelize": "5.0.0-beta.13"
+    "sequelize": "^5.3.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This pull request updates sequelize to the newest version, because there is a [security issue](https://nvd.nist.gov/vuln/detail/CVE-2019-11069) in all sequelize versions < 5.3.0.